### PR TITLE
Update plugin.xml to list only resources added by plugin

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -33,7 +33,10 @@
                      target-dir="src/com/transatel/plugins/barcodescanner"/>
         <source-file src="src/android/com/transatel/plugins/barcodescanner/CustomScannerActivity.java"
                      target-dir="src/com/transatel/plugins/barcodescanner"/>
-        <resource-file src="src/android/res" target="res"/>
+        <resource-file src="src/android/res/layout/custom_scanner.xml" target="res/layout/custom_scanner.xml"/>
+        <resource-file src="src/android/res/layout/custom_barcode_scanner.xml" target="res/layout/custom_barcode_scanner.xml"/>
+        <resource-file src="src/android/res/drawable/rounded_corners.xml" target="res/drawable/rounded_corners.xml"/>
+        <resource-file src="src/android/res/drawable/arrow_back.xml" target="res/drawable/arrow_back.xml"/>Ľ
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="BarcodeScanner">
                 <param name="android-package" value="com.transatel.plugins.barcodescanner.BarcodeScanner"/>


### PR DESCRIPTION
When 'res' directory mentioned in plugin.xml for android then this whole directory is deleted when plugin is removed from android build. But this plugin itself adds only four files to the 'res' directory, so only those four files need to be deleted